### PR TITLE
Added check for TILE_FIELD2 to handle added crops in 1.3

### DIFF
--- a/src/main/resources/net/bdew/wurm/tooltip/tilePicker.txt
+++ b/src/main/resources/net/bdew/wurm/tooltip/tilePicker.txt
@@ -15,7 +15,7 @@
 
     slope = slope.replace(" (", "").replace(")", "").trim();
     String suffix;
-    if (type == com.wurmonline.mesh.Tiles.Tile.TILE_FIELD) {
+    if (type == com.wurmonline.mesh.Tiles.Tile.TILE_FIELD || type == com.wurmonline.mesh.Tiles.Tile.TILE_FIELD2) {
         suffix = com.wurmonline.mesh.FieldData.getTypeName(type, data) + ", " + com.wurmonline.mesh.FieldData.getAgeName(data);
         if (!com.wurmonline.mesh.FieldData.isTended(data)) {
             suffix = suffix + ", untended";


### PR DESCRIPTION
Noticed that some crops wouldn't display crop tooltips, turns out there's a new field tile type (presumably to support more crop types).  One tweak later they're showing the crop tooltips.